### PR TITLE
make error message more descriptive

### DIFF
--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -47,7 +47,7 @@ def q_put():
     }
 
     if not url:
-        return {"success": False, "error": "/q called without a 'url' query param"}
+        return {"success": False, "error": "/q called without a 'url' in form data"}
 
     dl_q.put((url, options))
     print("Added url " + url + " to the download queue")


### PR DESCRIPTION
The error message is mentioning a query param, but the API accepts a POST request. This PR makes the error message a bit clearer.