### PR TITLE
Update Dockerfile to use Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # https://github.com/manbearwiz/youtube-dl-server-dockerfile
 #
 
-FROM python:alpine
+FROM python:3.10-alpine3.17
 
 RUN apk add --no-cache \
   ffmpeg \


### PR DESCRIPTION
I was getting build errors using python:alpine. The latest python getting pulled caused an issue running the pip install for `uvloop`.