### PR TITLE
Added support for new options: thumbnails, subtitles, metadata, etc.

### DIFF
--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -171,7 +171,7 @@ def get_ydl_options(request_options):
         "writethumbnail": ydl_vars["YDL_WRITE_THUMBNAIL"],
         "writesubtitles": ydl_vars["YDL_WRITE_SUBTITLES"],
         "subtitlesformat": ydl_vars["YDL_SUBTITLES_FORMAT"],
-        "subtitleslangs": ydl_vars["YDL_SUBTITLES_LANGS"],
+        "subtitleslangs": list(ydl_vars["YDL_SUBTITLES_LANGS"].split(",")),
     }
 
 

--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -28,6 +28,14 @@ app_defaults = {
     ),
     "YDL_ARCHIVE_FILE": config("YDL_ARCHIVE_FILE", default=None),
     "YDL_UPDATE_TIME": config("YDL_UPDATE_TIME", cast=bool, default=True),
+    "YDL_IGNORE_ERRORS": config("YDL_IGNORE_ERRORS", default=True),
+    "YDL_RESTRICT_FILENAMES": config("YDL_RESTRICT_FILENAMES", cast=bool, default=False),
+    "YDL_GEO_BYPASS": config("YDL_GEO_BYPASS", cast=bool, default=False),
+    "YDL_WRITE_THUMBNAIL": config("YDL_WRITE_THUMBNAIL", cast=bool, default=True),
+    "YDL_WRITE_SUBTITLES": config("YDL_WRITE_SUBTITLES", cast=bool, default=False),
+    "YDL_SUBTITLES_FORMAT": config("YDL_SUBTITLES_FORMAT", default=None),
+    "YDL_SUBTITLES_LANGS": config("YDL_SUBTITLES_LANGS", cast=str, default="all"),
+    "YDL_EMBED_METADATA": config("YDL_EMBED_METADATA", cast=bool, default=False),
 }
 
 
@@ -118,12 +126,42 @@ def get_ydl_options(request_options):
             }
         )
 
+    if ydl_vars["YDL_WRITE_THUMBNAIL"] == True:
+        postprocessors.append(
+            {
+                "key": "EmbedThumbnail",
+                "already_have_thumbnail": False,
+            }
+        )
+
+    if ydl_vars["YDL_WRITE_SUBTITLES"] == True:
+        postprocessors.append(
+            {
+                "key": "FFmpegEmbedSubtitle",
+                'already_have_subtitle': False,
+            }
+        )
+
+    if ydl_vars["YDL_EMBED_METADATA"] == True:
+        postprocessors.append(
+            {
+                "key": "FFmpegMetadata",
+            }
+        )
+
     return {
         "format": ydl_vars["YDL_FORMAT"],
         "postprocessors": postprocessors,
         "outtmpl": ydl_vars["YDL_OUTPUT_TEMPLATE"],
         "download_archive": ydl_vars["YDL_ARCHIVE_FILE"],
         "updatetime": ydl_vars["YDL_UPDATE_TIME"] == "True",
+        "ignoreerrors": ydl_vars["YDL_IGNORE_ERRORS"],
+        "restrictfilenames": ydl_vars["YDL_RESTRICT_FILENAMES"],
+        "geo_bypass": ydl_vars["YDL_GEO_BYPASS"],
+        "writethumbnail": ydl_vars["YDL_WRITE_THUMBNAIL"],
+        "writesubtitles": ydl_vars["YDL_WRITE_SUBTITLES"],
+        "subtitlesformat": ydl_vars["YDL_SUBTITLES_FORMAT"],
+        "subtitleslangs": ydl_vars["YDL_SUBTITLES_LANGS"],
     }
 
 

--- a/youtube-dl-server.py
+++ b/youtube-dl-server.py
@@ -32,6 +32,7 @@ app_defaults = {
     "YDL_RESTRICT_FILENAMES": config("YDL_RESTRICT_FILENAMES", cast=bool, default=False),
     "YDL_GEO_BYPASS": config("YDL_GEO_BYPASS", cast=bool, default=False),
     "YDL_WRITE_THUMBNAIL": config("YDL_WRITE_THUMBNAIL", cast=bool, default=True),
+    "YDL_THUMBNAIL_FORMAT": config("YDL_THUMBNAIL_FORMAT", default=None),
     "YDL_WRITE_SUBTITLES": config("YDL_WRITE_SUBTITLES", cast=bool, default=False),
     "YDL_SUBTITLES_FORMAT": config("YDL_SUBTITLES_FORMAT", default=None),
     "YDL_SUBTITLES_LANGS": config("YDL_SUBTITLES_LANGS", cast=str, default="all"),
@@ -131,6 +132,15 @@ def get_ydl_options(request_options):
             {
                 "key": "EmbedThumbnail",
                 "already_have_thumbnail": False,
+            }
+        )
+
+    if ydl_vars["YDL_THUMBNAIL_FORMAT"]:
+        postprocessors.append(
+            {
+                "key": "FFmpegThumbnailsConvertor",
+                "format": ydl_vars["YDL_THUMBNAIL_FORMAT"],
+                "when": "before_dl",
             }
         )
 


### PR DESCRIPTION
List of new environment variables which can be specified in a `.env` file before running `docker compose up` or can be passed via the `-e` flag when creating a container using `docker run`:

| Environment Variable | Type | Default Value | Example |
| --- | --- | --- | --- |
| YDL_IGNORE_ERRORS | String | True | `YTDL_IGNORE_ERRORS=True` |
YDL_RESTRICT_FILENAMES | Boolean | False | `YTDL_RESTRICT_FILENAMES=True` |
YDL_GEO_BYPASS | Boolean | False | `YTDL_GEO_BYPASS=True` |
YDL_WRITE_THUMBNAIL | Boolean | True | `YTDL_WRITE_THUMBNAIL=True` |
YDL_THUMBNAIL_FORMAT | String | None | `YTLD_THUMBNAIL_FORMAT="jpg"` |
YDL_WRITE_SUBTITLES | Boolean | False | `YTDL_WRITE_SUBTITLES=True` |
YDL_SUBTITLES_FORMAT | String | None | `YTDL_SUBTITLES_FORMAT="srt"` |
YDL_SUBTITLES_LANGS | String | all | `YTDL_SUBTITLES_LANGS="en,ja"` |
YDL_EMBED_METADATA | Boolean | False | `YTDL_EMBED_METADATA=True` |

Can test with the Docker image `qx6ghqkz/youtube-dl-server:latest` [found here](https://hub.docker.com/r/qx6ghqkz/youtube-dl-server).

Solves #29 and #33 .

For more information on these options see [yt-dlp/YoutubeDL.py](https://github.com/yt-dlp/yt-dlp/blob/12b248ce60be1aa1362edd839d915bba70dbee4b/yt_dlp/YoutubeDL.py#L176-L565).